### PR TITLE
Update download link to latest (2.1.669)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     </div>
 
     <div class="buttonHost">
-        <a download href="https://github.com/KirillOsenkov/MSBuildStructuredLog/releases/download/v2.1.627/MSBuildStructuredLogSetup.exe" class="bigButton">Download&nbsp;MSBuild&nbsp;Structured&nbsp;Log&nbsp;Viewer</a>
+        <a download href="https://github.com/KirillOsenkov/MSBuildStructuredLog/releases/latest/download/MSBuildStructuredLogSetup.exe" class="bigButton">Download&nbsp;MSBuild&nbsp;Structured&nbsp;Log&nbsp;Viewer</a>
         <a href="https://live.msbuildlog.com" class="bigButton">Open&nbsp;Online&nbsp;Structured&nbsp;Log&nbsp;Viewer</a>
     </div>
 


### PR DESCRIPTION
I'm not sure if this is desired but throwing up a PR to reduce maintenance if wanted. You can link to the latest release with a slightly different format: `https://github.com/KirillOsenkov/MSBuildStructuredLog/releases/latest/download/MSBuildStructuredLogSetup.exe` - this will always grab the latest release for that repo. More details here on linking formats: https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases

No worries if unwanted and a specific version is desired here - just close away :)