### PR TITLE
Add instructions for using dotnet build

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,10 @@
     <img src="BinLogFromCommandLine.png" width="70%" />
     <p>Double-click the <span class="inlineCode">.binlog</span> file to open it in MSBuild Structured Log Viewer:</p>
     <img src="Screenshot1.png" width="100%" />
+    
+    <h2 id="usingdotnet">Using dotnet build -bl to record a binary log</h2>
+    <p>You can also produce binary logs from the <span class="inlineCode">dotnet build</span> command by passing the <span class="inlineCode">-bl</span> argument:</p>
+    <div class="code">dotnet build -bl</div>
 
     <h2 id="replay">Replaying a .binlog to reconstruct text logs</h2>
     <p>You can pass a <span class="inlineCode">.binlog</span> file to MSBuild instead of a project/solution to replay it to other loggers, as if a real build was happening. This allows you to reconstruct a text log of any verbosity given the <span class="inlineCode">.binlog</span> file. Read more at: <a href="https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Binary-Log.md#replaying-a-binary-log">https://github.com/Microsoft/msbuild/wiki/Binary-Log#replaying-a-binary-log</a></p>


### PR DESCRIPTION
This PR adds some simple instructions for using `dotnet build -bl` to make it clear that's an option